### PR TITLE
Bump defaults to 512MiB RAM, default os debian13, disk size 8GiB

### DIFF
--- a/AppConfig.cs
+++ b/AppConfig.cs
@@ -6,10 +6,10 @@ public class AppConfig
   public string CacheDir { get; private set; }
   public string DataDir { get; private set; }
   public string DefaultVmName { get; set; } = "testvm";
-  public string DefaultVmDistro { get; set; } = "Debian11";
+  public string DefaultVmDistro { get; set; } = "Debian13";
   public string DefaultUser { get; set; } = "user";
-  public string DefaultMemorySize { get; set; } = "256MiB";
-  public string DefaultDiskSize { get; set; } = "4GiB";
+  public string DefaultMemorySize { get; set; } = "512MiB";
+  public string DefaultDiskSize { get; set; } = "8GiB";
   public int DefaultCpuCount { get; set; } = 1;
 
   public AppConfig(string appName = "VmChamp", string sessionName = "default")


### PR DESCRIPTION
Closes #22 #19 