### PR TITLE
feat(DistroInfo): add Fedora 43 and Fedora 44 cloud images

### DIFF
--- a/DistroInfo.cs
+++ b/DistroInfo.cs
@@ -176,6 +176,26 @@ public class DistroInfo
     },
     new()
     {
+      Name = "Fedora43",
+      Family = "Fedora",
+      ImageName = "Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2",
+      Url = "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images/",
+      Aliases = Array.Empty<string>(),
+      ChecksumFile = "Fedora-Cloud-43-1.6-x86_64-CHECKSUM",
+      ChecksumType = "sha256"
+    },
+    new()
+    {
+      Name = "Fedora44",
+      Family = "Fedora",
+      ImageName = "Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2",
+      Url = "https://download.fedoraproject.org/pub/fedora/linux/releases/44/Cloud/x86_64/images/",
+      Aliases = Array.Empty<string>(),
+      ChecksumFile = "Fedora-Cloud-44-1.7-x86_64-CHECKSUM",
+      ChecksumType = "sha256"
+    },
+    new()
+    {
       Name = "CentOS7",
       Family = "RHEL",
       ImageName = "CentOS-7-x86_64-GenericCloud.qcow2",


### PR DESCRIPTION
closes #28 